### PR TITLE
Array parsing accommodates spaces as well as commas

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ const parse = (transformString: string): TransformObject => {
   return transforms.reduce((acc, transform: string) => {
     if (!transform) return acc;
     const [name, transformValue] = transform.split('(');
-    const valueArray = transformValue.split(',');
+    const valueArray = transformValue.split(/\s|,/);
     const values = valueArray.map((val) => {
       return parsePixelValues(val.endsWith(')') ? val.replace(')', '') : val.trim());
     });


### PR DESCRIPTION
You can define transforms as `translate(100,200,300)' or 'translate(100 200 300)'. Both can be used validly when reading them, but transform-parser only accepts the former. This uses regex to accept the latter too.